### PR TITLE
ALEC-308: Chart LLM token usage on the Resource Graphs

### DIFF
--- a/docs/modules/reference/pages/llm-root-cause-analysis.adoc
+++ b/docs/modules/reference/pages/llm-root-cause-analysis.adoc
@@ -91,6 +91,25 @@ To reduce or eliminate cost, you can:
 * Choose a less expensive model.
 * Use a xref:reference:llm-root-cause-analysis.adoc#local-llm[locally run LLM].
 
+== Usage metrics on the Resource Graphs
+
+Every LLM token ALEC spends — by root cause analysis, by the LLM clustering engine and by the configuration page's validation probes — is counted and exposed as ALEC metrics over JMX, in the same JMX domain as the correlation engine's own gauges.
+OpenNMS's stock JMX data collection already collects that domain, so the counters appear as *ALEC Graph Stats* resource graphs of the OpenNMS node with no configuration change, and OpenNMS thresholds can alert on them.
+
+[cols="1,2"]
+|===
+| Gauge | Meaning
+
+| `llmTokens` | Total LLM tokens since ALEC started, all buckets and consumers.
+| `llmInputTokens`, `llmOutputTokens`, `llmCacheReadTokens`, `llmCacheCreationTokens` | Tokens by bucket, kept disjoint so they sum to `llmTokens`.
+| `llmTokensRca`, `llmTokensClustering`, `llmTokensValidation` | Tokens by consumer.
+| `llmCalls`, `llmFailedCalls`, `llmCallsRca`, `llmCallsClustering` | LLM exchanges and failures, overall and by consumer.
+| `llmTokenRate1m`, `llmTokenRate5m` | Tokens per second, one- and five-minute moving averages — the graph to watch for a runaway model.
+|===
+
+The counters reset when the ALEC bundles restart.
+The durable per-call history that the usage summary and the token budgets use is kept separately in the OpenNMS key-value store; the JMX gauges are the time-series view of the same activity.
+
 == Data privacy
 
 When the feature is enabled, ALEC sends the affected situation's alarm data — including node, interface, service, severity, timing, and any embedded SNMP or syslog text — to the configured endpoint.

--- a/driver/main/src/main/java/org/opennms/alec/driver/main/Driver.java
+++ b/driver/main/src/main/java/org/opennms/alec/driver/main/Driver.java
@@ -34,6 +34,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -64,6 +65,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.MetricSet;
 import com.codahale.metrics.jmx.JmxReporter;
 
 public class Driver implements EngineRegistry {
@@ -366,5 +368,40 @@ public class Driver implements EngineRegistry {
 
     public MetricRegistry getMetrics() {
         return metrics;
+    }
+
+    /**
+     * Blueprint reference-list bind method: fold a {@link MetricSet} published
+     * by another ALEC bundle into this driver's registry, so its gauges are
+     * reported over JMX in the same domain as the engine's own metrics
+     * ({@code org.opennms.alec.driver.main.Driver.<engine>}) — the domain
+     * OpenNMS's stock JMX collection already charts. ALEC-308 uses this for
+     * the LLM token-usage gauges. Safe to call before or after the reporter
+     * starts: JmxReporter registers metrics added later as they appear.
+     */
+    public void registerMetricSet(MetricSet metricSet) {
+        if (metricSet == null) {
+            return;
+        }
+        for (Map.Entry<String, com.codahale.metrics.Metric> e : metricSet.getMetrics().entrySet()) {
+            // Re-binding after a bundle restart must not throw on the duplicate name.
+            metrics.remove(e.getKey());
+            try {
+                metrics.register(e.getKey(), e.getValue());
+            } catch (IllegalArgumentException ex) {
+                LOG.warn("Could not register contributed metric {}: {}", e.getKey(), ex.getMessage());
+            }
+        }
+        LOG.debug("Registered {} contributed metric(s)", metricSet.getMetrics().size());
+    }
+
+    /** Blueprint reference-list unbind method. */
+    public void unregisterMetricSet(MetricSet metricSet) {
+        if (metricSet == null) {
+            return;
+        }
+        for (String name : metricSet.getMetrics().keySet()) {
+            metrics.remove(name);
+        }
     }
 }

--- a/driver/main/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/driver/main/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -37,6 +37,35 @@
     </bean>
     <service ref="driver" interface="org.opennms.alec.engine.api.EngineRegistry"/>
 
+    <!--
+        LLM token usage gauges (ALEC-308). The driver owns the bean and
+        publishes it both as the LlmUsageMetrics sink the LLM features record
+        into and as a MetricSet the whiteboard below folds into the driver's
+        JMX-reported registry, so OpenNMS charts the counters next to the
+        engine's own gauges.
+    -->
+    <bean id="llmUsageMetrics" class="org.opennms.alec.engine.api.llm.DefaultLlmUsageMetrics"/>
+    <service ref="llmUsageMetrics" interface="org.opennms.alec.engine.api.llm.LlmUsageMetrics"/>
+    <service ref="llmUsageMetrics" interface="com.codahale.metrics.MetricSet">
+        <service-properties>
+            <entry key="name" value="alec-llm-usage"/>
+        </service-properties>
+    </service>
+
+    <!--
+        Metric sets contributed by ALEC bundles (the LLM usage gauges above,
+        and any a later feature publishes). They are folded into the driver's
+        registry so they appear under the engine's JMX domain and get charted
+        by OpenNMS like the engine's own gauges.
+    -->
+    <reference-list id="contributedMetricSets"
+                    interface="com.codahale.metrics.MetricSet"
+                    availability="optional">
+        <reference-listener bind-method="registerMetricSet" unbind-method="unregisterMetricSet">
+            <ref component-id="driver"/>
+        </reference-listener>
+    </reference-list>
+
     <!-- Expose a health check that can be used when we're running in an OpenNMS container -->
     <bean id="healthCheck" class="org.opennms.alec.driver.main.DriverHealthCheck">
         <argument ref="driver"/>

--- a/driver/main/src/test/java/org/opennms/alec/driver/main/DriverTest.java
+++ b/driver/main/src/test/java/org/opennms/alec/driver/main/DriverTest.java
@@ -29,13 +29,19 @@
 package org.opennms.alec.driver.main;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.Test;
 import org.opennms.alec.datasource.api.AlarmDatasource;
@@ -47,9 +53,80 @@ import org.opennms.alec.processor.api.SituationProcessor;
 import org.opennms.alec.processor.api.SituationProcessorFactory;
 import org.osgi.framework.BundleContext;
 
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.MetricSet;
 
 public class DriverTest {
+
+    /** A contributed MetricSet in the shape the MCP bundle publishes (ALEC-308): live gauges. */
+    private static MetricSet gaugeSet(AtomicLong calls, AtomicLong errors) {
+        return () -> {
+            Map<String, Metric> m = new LinkedHashMap<>();
+            m.put("toolCalls", (Gauge<Long>) calls::get);
+            m.put("toolErrors", (Gauge<Long>) errors::get);
+            return m;
+        };
+    }
+
+    private static Driver newDriver() {
+        BundleContext bundleContext = mock(BundleContext.class);
+        EngineFactory engineFactory = mock(EngineFactory.class);
+        when(engineFactory.getName()).thenReturn("test-engine");
+        SituationProcessorFactory situationProcessorFactory = mock(SituationProcessorFactory.class);
+        when(situationProcessorFactory.getInstance()).thenReturn(mock(SituationProcessor.class));
+        return new Driver(bundleContext, mock(AlarmDatasource.class), mock(AlarmFeedbackDatasource.class),
+                mock(InventoryDatasource.class), mock(SituationDatasource.class), engineFactory,
+                situationProcessorFactory);
+    }
+
+    @Test
+    public void registerMetricSetFoldsContributedGaugesIntoTheDriverRegistry() {
+        Driver driver = newDriver();
+        AtomicLong calls = new AtomicLong(3);
+        AtomicLong errors = new AtomicLong(1);
+        MetricSet set = gaugeSet(calls, errors);
+
+        driver.registerMetricSet(set);
+        MetricRegistry registry = driver.getMetrics();
+        assertThat(registry.getGauges().containsKey("toolCalls"), is(true));
+        assertThat(registry.getGauges().containsKey("toolErrors"), is(true));
+        assertThat("the gauge is live, not a copy",
+                (Long) registry.getGauges().get("toolCalls").getValue(), equalTo(3L));
+        calls.incrementAndGet();
+        assertThat((Long) registry.getGauges().get("toolCalls").getValue(), equalTo(4L));
+        assertThat("the driver's own metrics are untouched", registry.getTimers().containsKey("ticks"), is(true));
+
+        driver.unregisterMetricSet(set);
+        assertThat(registry.getGauges().containsKey("toolCalls"), is(false));
+        assertThat(registry.getGauges().containsKey("toolErrors"), is(false));
+        assertThat(registry.getTimers().containsKey("ticks"), is(true));
+    }
+
+    @Test
+    public void reRegisteringTheSameMetricNamesDoesNotThrow() {
+        Driver driver = newDriver();
+        AtomicLong first = new AtomicLong(1);
+        MetricSet original = gaugeSet(first, new AtomicLong());
+        driver.registerMetricSet(original);
+        driver.registerMetricSet(original); // same instance again (bundle refresh)
+
+        AtomicLong second = new AtomicLong(42);
+        driver.registerMetricSet(gaugeSet(second, new AtomicLong())); // a replacement after a bundle restart
+        assertThat("the later registration wins",
+                (Long) driver.getMetrics().getGauges().get("toolCalls").getValue(), equalTo(42L));
+    }
+
+    @Test
+    public void nullMetricSetsAreIgnored() {
+        Driver driver = newDriver();
+        driver.registerMetricSet(null);
+        driver.unregisterMetricSet(null);
+        assertThat(driver.getMetrics().getGauges().get("toolCalls"), nullValue());
+        // unregistering something never registered is harmless too
+        driver.unregisterMetricSet(gaugeSet(new AtomicLong(), new AtomicLong()));
+    }
 
     @Test
     public void canGenerateTicks() throws InterruptedException, ExecutionException {

--- a/engine/api/pom.xml
+++ b/engine/api/pom.xml
@@ -23,5 +23,15 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/engine/api/src/main/java/org/opennms/alec/engine/api/llm/DefaultLlmUsageMetrics.java
+++ b/engine/api/src/main/java/org/opennms/alec/engine/api/llm/DefaultLlmUsageMetrics.java
@@ -1,0 +1,156 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2026 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2026 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.alec.engine.api.llm;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.LongAdder;
+
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
+
+/**
+ * Cumulative LLM token usage as a Dropwizard {@link MetricSet} of gauges.
+ * Published as an OSGi service by the driver's blueprint, folded by the ALEC
+ * driver into the engine's JMX-reported registry and therefore charted by
+ * OpenNMS's stock JMX collection ("ALEC Graph Stats") with no OpenNMS-side
+ * change. Gauges only, because that collection's
+ * wildcard matches the gauges type; the per-minute rates are exposed as gauges
+ * too so a graph shows spend as a rate and not only a rising total.
+ *
+ * <p>Counters reset when the bundle restarts. The durable per-call history —
+ * what the settings page and the token budget use — stays in the KV usage
+ * store; this is the time-series view of the same numbers.
+ */
+public class DefaultLlmUsageMetrics implements LlmUsageMetrics, MetricSet {
+
+    private static final Consumer[] CONSUMERS = Consumer.values();
+
+    public static final String TOKENS = "llmTokens";
+    public static final String INPUT_TOKENS = "llmInputTokens";
+    public static final String OUTPUT_TOKENS = "llmOutputTokens";
+    public static final String CACHE_READ_TOKENS = "llmCacheReadTokens";
+    public static final String CACHE_CREATION_TOKENS = "llmCacheCreationTokens";
+    public static final String CALLS = "llmCalls";
+    public static final String FAILED_CALLS = "llmFailedCalls";
+    public static final String TOKENS_RCA = "llmTokensRca";
+    public static final String TOKENS_CLUSTERING = "llmTokensClustering";
+    public static final String TOKENS_VALIDATION = "llmTokensValidation";
+    public static final String CALLS_RCA = "llmCallsRca";
+    public static final String CALLS_CLUSTERING = "llmCallsClustering";
+    public static final String TOKEN_RATE_1M = "llmTokenRate1m";
+    public static final String TOKEN_RATE_5M = "llmTokenRate5m";
+
+    private final Meter tokens = new Meter();
+    private final LongAdder inputTokens = new LongAdder();
+    private final LongAdder outputTokens = new LongAdder();
+    private final LongAdder cacheReadTokens = new LongAdder();
+    private final LongAdder cacheCreationTokens = new LongAdder();
+    private final LongAdder calls = new LongAdder();
+    private final LongAdder failedCalls = new LongAdder();
+    private final Map<Consumer, LongAdder> tokensByConsumer = new EnumMap<>(Consumer.class);
+    private final Map<Consumer, LongAdder> callsByConsumer = new EnumMap<>(Consumer.class);
+
+    public DefaultLlmUsageMetrics() {
+        for (Consumer c : CONSUMERS) {
+            tokensByConsumer.put(c, new LongAdder());
+            callsByConsumer.put(c, new LongAdder());
+        }
+    }
+
+    @Override
+    public void recordRound(Consumer consumer, TokenUsage usage) {
+        if (usage == null) {
+            return;
+        }
+        long total = usage.getTotalTokens();
+        if (total > 0) {
+            tokens.mark(total);
+        }
+        inputTokens.add(usage.getInputTokens());
+        outputTokens.add(usage.getOutputTokens());
+        cacheReadTokens.add(usage.getCacheReadInputTokens());
+        cacheCreationTokens.add(usage.getCacheCreationInputTokens());
+        tokensByConsumer.get(consumer == null ? Consumer.RCA : consumer).add(total);
+    }
+
+    @Override
+    public void recordCall(Consumer consumer, boolean success) {
+        calls.increment();
+        if (!success) {
+            failedCalls.increment();
+        }
+        callsByConsumer.get(consumer == null ? Consumer.RCA : consumer).increment();
+    }
+
+    public long getTotalTokens() {
+        return tokens.getCount();
+    }
+
+    public long getTokens(Consumer consumer) {
+        return tokensByConsumer.get(consumer).sum();
+    }
+
+    public long getCalls() {
+        return calls.sum();
+    }
+
+    public long getFailedCalls() {
+        return failedCalls.sum();
+    }
+
+    public long getCalls(Consumer consumer) {
+        return callsByConsumer.get(consumer).sum();
+    }
+
+    @Override
+    public Map<String, Metric> getMetrics() {
+        Map<String, Metric> m = new LinkedHashMap<>();
+        m.put(TOKENS, (Gauge<Long>) tokens::getCount);
+        m.put(INPUT_TOKENS, (Gauge<Long>) inputTokens::sum);
+        m.put(OUTPUT_TOKENS, (Gauge<Long>) outputTokens::sum);
+        m.put(CACHE_READ_TOKENS, (Gauge<Long>) cacheReadTokens::sum);
+        m.put(CACHE_CREATION_TOKENS, (Gauge<Long>) cacheCreationTokens::sum);
+        m.put(CALLS, (Gauge<Long>) calls::sum);
+        m.put(FAILED_CALLS, (Gauge<Long>) failedCalls::sum);
+        m.put(TOKENS_RCA, (Gauge<Long>) () -> getTokens(Consumer.RCA));
+        m.put(TOKENS_CLUSTERING, (Gauge<Long>) () -> getTokens(Consumer.CLUSTERING));
+        m.put(TOKENS_VALIDATION, (Gauge<Long>) () -> getTokens(Consumer.VALIDATION));
+        m.put(CALLS_RCA, (Gauge<Long>) () -> getCalls(Consumer.RCA));
+        m.put(CALLS_CLUSTERING, (Gauge<Long>) () -> getCalls(Consumer.CLUSTERING));
+        m.put(TOKEN_RATE_1M, (Gauge<Double>) tokens::getOneMinuteRate);
+        m.put(TOKEN_RATE_5M, (Gauge<Double>) tokens::getFiveMinuteRate);
+        return Collections.unmodifiableMap(m);
+    }
+}

--- a/engine/api/src/main/java/org/opennms/alec/engine/api/llm/LlmUsageMetrics.java
+++ b/engine/api/src/main/java/org/opennms/alec/engine/api/llm/LlmUsageMetrics.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2026 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2026 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.alec.engine.api.llm;
+
+/**
+ * Sink for LLM token usage, fed by every chat exchange ALEC makes — root
+ * cause analysis, LLM clustering and the configuration-page probes. The
+ * default implementation publishes the counts as Dropwizard gauges the
+ * driver reports over JMX, which OpenNMS's stock JMX collection charts on
+ * the node's Resource Graphs. An interface so blueprint references in other
+ * bundles can proxy it.
+ */
+public interface LlmUsageMetrics {
+
+    /** Which ALEC feature made the call — a dimension on the gauges. */
+    enum Consumer {
+        /** Root cause analysis (features/llm-suggestions). */
+        RCA("rca"),
+        /** The LLM clustering engine (engine/llm). */
+        CLUSTERING("clustering"),
+        /** The configuration page's validation probes. */
+        VALIDATION("validation");
+
+        private final String key;
+
+        Consumer(String key) {
+            this.key = key;
+        }
+
+        public String getKey() {
+            return key;
+        }
+    }
+
+    /** One chat-completions response's usage block. Called once per round trip. */
+    void recordRound(Consumer consumer, TokenUsage usage);
+
+    /** One whole exchange finished, successfully or not. */
+    void recordCall(Consumer consumer, boolean success);
+}

--- a/engine/api/src/main/java/org/opennms/alec/engine/api/llm/TokenUsage.java
+++ b/engine/api/src/main/java/org/opennms/alec/engine/api/llm/TokenUsage.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2026 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2026 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.alec.engine.api.llm;
+
+/**
+ * Token counts for one or more chat-completions calls, with the buckets kept
+ * disjoint: {@code inputTokens} excludes the automatically-cached input that
+ * providers report under {@code prompt_tokens_details.cached_tokens}, so the
+ * sum of all buckets is the true total.
+ */
+public final class TokenUsage {
+
+    private static final TokenUsage EMPTY = new TokenUsage(0, 0, 0, 0);
+
+    private final long inputTokens;
+    private final long outputTokens;
+    private final long cacheReadInputTokens;
+    private final long cacheCreationInputTokens;
+
+    public TokenUsage(long inputTokens, long outputTokens, long cacheReadInputTokens,
+                      long cacheCreationInputTokens) {
+        this.inputTokens = inputTokens;
+        this.outputTokens = outputTokens;
+        this.cacheReadInputTokens = cacheReadInputTokens;
+        this.cacheCreationInputTokens = cacheCreationInputTokens;
+    }
+
+    public static TokenUsage empty() {
+        return EMPTY;
+    }
+
+    public TokenUsage plus(TokenUsage other) {
+        if (other == null) {
+            return this;
+        }
+        return new TokenUsage(inputTokens + other.inputTokens,
+                outputTokens + other.outputTokens,
+                cacheReadInputTokens + other.cacheReadInputTokens,
+                cacheCreationInputTokens + other.cacheCreationInputTokens);
+    }
+
+    public long getInputTokens() {
+        return inputTokens;
+    }
+
+    public long getOutputTokens() {
+        return outputTokens;
+    }
+
+    public long getCacheReadInputTokens() {
+        return cacheReadInputTokens;
+    }
+
+    public long getCacheCreationInputTokens() {
+        return cacheCreationInputTokens;
+    }
+
+    public long getTotalTokens() {
+        return inputTokens + outputTokens + cacheReadInputTokens + cacheCreationInputTokens;
+    }
+
+    @Override
+    public String toString() {
+        return "TokenUsage[in=" + inputTokens + ", out=" + outputTokens + ", cacheRead="
+                + cacheReadInputTokens + ", cacheCreate=" + cacheCreationInputTokens + "]";
+    }
+}

--- a/engine/api/src/test/java/org/opennms/alec/engine/api/llm/DefaultLlmUsageMetricsTest.java
+++ b/engine/api/src/test/java/org/opennms/alec/engine/api/llm/DefaultLlmUsageMetricsTest.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2026 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2026 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.alec.engine.api.llm;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.junit.Assert.assertThat;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+
+public class DefaultLlmUsageMetricsTest {
+
+    @Test
+    public void exposesAllGaugesWithTheDocumentedNames() {
+        Map<String, Metric> m = new DefaultLlmUsageMetrics().getMetrics();
+        assertThat(m.size(), equalTo(14));
+        assertThat(m.keySet(), hasItems(
+                DefaultLlmUsageMetrics.TOKENS, DefaultLlmUsageMetrics.INPUT_TOKENS,
+                DefaultLlmUsageMetrics.OUTPUT_TOKENS, DefaultLlmUsageMetrics.CACHE_READ_TOKENS,
+                DefaultLlmUsageMetrics.CACHE_CREATION_TOKENS, DefaultLlmUsageMetrics.CALLS,
+                DefaultLlmUsageMetrics.FAILED_CALLS, DefaultLlmUsageMetrics.TOKENS_RCA,
+                DefaultLlmUsageMetrics.TOKENS_CLUSTERING, DefaultLlmUsageMetrics.TOKENS_VALIDATION,
+                DefaultLlmUsageMetrics.CALLS_RCA, DefaultLlmUsageMetrics.CALLS_CLUSTERING,
+                DefaultLlmUsageMetrics.TOKEN_RATE_1M, DefaultLlmUsageMetrics.TOKEN_RATE_5M));
+        for (Metric metric : m.values()) {
+            assertThat("every metric is a gauge (the JMX collection wildcard matches gauges only)",
+                    metric instanceof Gauge, equalTo(true));
+        }
+    }
+
+    @Test
+    public void sumsRoundsIntoBucketsAndPerConsumerTotals() {
+        DefaultLlmUsageMetrics metrics = new DefaultLlmUsageMetrics();
+        metrics.recordRound(LlmUsageMetrics.Consumer.RCA, new TokenUsage(100, 20, 30, 0));
+        metrics.recordRound(LlmUsageMetrics.Consumer.RCA, new TokenUsage(50, 10, 0, 5));
+        metrics.recordRound(LlmUsageMetrics.Consumer.CLUSTERING, new TokenUsage(200, 40, 0, 0));
+        metrics.recordRound(LlmUsageMetrics.Consumer.VALIDATION, new TokenUsage(10, 1, 0, 0));
+        metrics.recordRound(LlmUsageMetrics.Consumer.RCA, null); // ignored
+        Map<String, Metric> m = metrics.getMetrics();
+        assertThat(value(m, DefaultLlmUsageMetrics.TOKENS), equalTo(466L));
+        assertThat(value(m, DefaultLlmUsageMetrics.INPUT_TOKENS), equalTo(360L));
+        assertThat(value(m, DefaultLlmUsageMetrics.OUTPUT_TOKENS), equalTo(71L));
+        assertThat(value(m, DefaultLlmUsageMetrics.CACHE_READ_TOKENS), equalTo(30L));
+        assertThat(value(m, DefaultLlmUsageMetrics.CACHE_CREATION_TOKENS), equalTo(5L));
+        assertThat(value(m, DefaultLlmUsageMetrics.TOKENS_RCA), equalTo(215L));
+        assertThat(value(m, DefaultLlmUsageMetrics.TOKENS_CLUSTERING), equalTo(240L));
+        assertThat(value(m, DefaultLlmUsageMetrics.TOKENS_VALIDATION), equalTo(11L));
+    }
+
+    @Test
+    public void countsCallsAndFailuresPerConsumer() {
+        DefaultLlmUsageMetrics metrics = new DefaultLlmUsageMetrics();
+        metrics.recordCall(LlmUsageMetrics.Consumer.RCA, true);
+        metrics.recordCall(LlmUsageMetrics.Consumer.RCA, false);
+        metrics.recordCall(LlmUsageMetrics.Consumer.CLUSTERING, true);
+        metrics.recordCall(LlmUsageMetrics.Consumer.VALIDATION, false);
+        Map<String, Metric> m = metrics.getMetrics();
+        assertThat(value(m, DefaultLlmUsageMetrics.CALLS), equalTo(4L));
+        assertThat(value(m, DefaultLlmUsageMetrics.FAILED_CALLS), equalTo(2L));
+        assertThat(value(m, DefaultLlmUsageMetrics.CALLS_RCA), equalTo(2L));
+        assertThat(value(m, DefaultLlmUsageMetrics.CALLS_CLUSTERING), equalTo(1L));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static long value(Map<String, Metric> m, String name) {
+        return ((Gauge<Long>) m.get(name)).getValue();
+    }
+}

--- a/engine/llm/src/main/java/org/opennms/alec/engine/llm/LlmClusterEngine.java
+++ b/engine/llm/src/main/java/org/opennms/alec/engine/llm/LlmClusterEngine.java
@@ -55,6 +55,8 @@ import org.opennms.alec.engine.cluster.AbstractClusterEngine;
 import org.opennms.alec.engine.cluster.AlarmInSpaceTime;
 import org.opennms.alec.engine.cluster.CEEdge;
 import org.opennms.alec.engine.cluster.CEVertex;
+import org.opennms.alec.engine.api.llm.LlmUsageMetrics;
+import org.opennms.alec.engine.api.llm.TokenUsage;
 import org.opennms.integration.api.v1.distributed.KeyValueStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -127,6 +129,9 @@ public class LlmClusterEngine extends AbstractClusterEngine {
     private final ObjectMapper objectMapper;
     private final String clusterPrompt;
     private final OkHttpClient httpClient;
+    // ALEC-308: token-usage gauges. Null, or a blueprint proxy that may throw
+    // when the driver is absent — recording is best-effort either way.
+    private final LlmUsageMetrics usageMetrics;
 
     // The LLM call is made off the engine tick thread so it never blocks under
     // the graph lock. Each tick fires at most one request (requestInFlight) and
@@ -166,7 +171,13 @@ public class LlmClusterEngine extends AbstractClusterEngine {
 
     LlmClusterEngine(MetricRegistry metrics, KeyValueStore<String> kvStore,
                      ObjectMapper objectMapper, String clusterPrompt) {
+        this(metrics, kvStore, objectMapper, clusterPrompt, null);
+    }
+
+    LlmClusterEngine(MetricRegistry metrics, KeyValueStore<String> kvStore,
+                     ObjectMapper objectMapper, String clusterPrompt, LlmUsageMetrics usageMetrics) {
         super(metrics);
+        this.usageMetrics = usageMetrics;
         this.kvStore = kvStore;
         this.objectMapper = objectMapper;
         this.clusterPrompt = (clusterPrompt == null || clusterPrompt.trim().isEmpty())
@@ -318,15 +329,19 @@ public class LlmClusterEngine extends AbstractClusterEngine {
                     if (!response.isSuccessful()) {
                         LOG.warn("LLM clustering API returned HTTP {}: {}", response.code(),
                                 truncate(text, 300));
+                        recordCallMetric(false);
                         return;
                     }
                     recordUsage(text, model, timestampInMillis);
                     latestGroups = parseGroups(text, objectMapper);
+                    recordCallMetric(true);
                 }
             } catch (IOException e) {
                 LOG.warn("LLM clustering call failed: {}", e.getMessage());
+                recordCallMetric(false);
             } catch (Exception e) {
                 LOG.error("Unexpected error during LLM clustering", e);
+                recordCallMetric(false);
             } finally {
                 requestInFlight.set(false);
             }
@@ -674,6 +689,7 @@ public class LlmClusterEngine extends AbstractClusterEngine {
             // handling); store the buckets disjointly to avoid double-counting.
             long cached = Math.min(prompt,
                     usage.path("prompt_tokens_details").path("cached_tokens").asLong(0));
+            recordRoundMetric(new TokenUsage(prompt - cached, usage.path("completion_tokens").asLong(0), cached, 0L));
             ObjectNode rec = objectMapper.createObjectNode();
             rec.put("ts", now);
             rec.put("situationId", CLUSTER_USAGE_MARKER);
@@ -700,6 +716,29 @@ public class LlmClusterEngine extends AbstractClusterEngine {
             }
         } catch (Exception e) {
             LOG.warn("Failed to record LLM clustering token usage: {}", e.getMessage());
+        }
+    }
+
+    /** Best-effort: the metrics sink is a blueprint proxy that throws when the driver bundle is down. */
+    private void recordRoundMetric(TokenUsage usage) {
+        if (usageMetrics == null) {
+            return;
+        }
+        try {
+            usageMetrics.recordRound(LlmUsageMetrics.Consumer.CLUSTERING, usage);
+        } catch (RuntimeException e) {
+            LOG.debug("LLM usage metrics unavailable: {}", e.getMessage());
+        }
+    }
+
+    private void recordCallMetric(boolean success) {
+        if (usageMetrics == null) {
+            return;
+        }
+        try {
+            usageMetrics.recordCall(LlmUsageMetrics.Consumer.CLUSTERING, success);
+        } catch (RuntimeException e) {
+            LOG.debug("LLM usage metrics unavailable: {}", e.getMessage());
         }
     }
 

--- a/engine/llm/src/main/java/org/opennms/alec/engine/llm/LlmEngineFactory.java
+++ b/engine/llm/src/main/java/org/opennms/alec/engine/llm/LlmEngineFactory.java
@@ -29,6 +29,7 @@
 package org.opennms.alec.engine.llm;
 
 import org.opennms.alec.engine.api.EngineFactory;
+import org.opennms.alec.engine.api.llm.LlmUsageMetrics;
 import org.opennms.integration.api.v1.distributed.KeyValueStore;
 
 import com.codahale.metrics.MetricRegistry;
@@ -41,13 +42,20 @@ public class LlmEngineFactory implements EngineFactory {
 
     private final KeyValueStore<String> kvStore;
     private final ObjectMapper objectMapper;
+    // Token-usage gauges (JMX); null when absent.
+    private final LlmUsageMetrics usageMetrics;
 
     private long clusterFrequencyMs = DEFAULT_CLUSTER_FREQUENCY_MS;
     private String clusterPrompt = "";
 
     public LlmEngineFactory(KeyValueStore<String> kvStore, ObjectMapper objectMapper) {
+        this(kvStore, objectMapper, null);
+    }
+
+    public LlmEngineFactory(KeyValueStore<String> kvStore, ObjectMapper objectMapper, LlmUsageMetrics usageMetrics) {
         this.kvStore = kvStore;
         this.objectMapper = objectMapper;
+        this.usageMetrics = usageMetrics;
     }
 
     @Override
@@ -62,7 +70,7 @@ public class LlmEngineFactory implements EngineFactory {
 
     @Override
     public LlmClusterEngine createEngine(MetricRegistry metrics) {
-        LlmClusterEngine engine = new LlmClusterEngine(metrics, kvStore, objectMapper, clusterPrompt);
+        LlmClusterEngine engine = new LlmClusterEngine(metrics, kvStore, objectMapper, clusterPrompt, usageMetrics);
         // Decouple the (possibly hour-long) LLM query cadence from the reconcile
         // cadence. The configured frequency throttles how often a NEW grouping is
         // requested; the engine still ticks at the faster reconcile interval so a

--- a/engine/llm/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/engine/llm/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -6,10 +6,19 @@
 
     <bean id="llmEngineObjectMapper" class="com.fasterxml.jackson.databind.ObjectMapper"/>
 
+    <!--
+        ALEC-308: LLM token usage gauges, published by the driver bundle.
+        Optional so this bundle resolves without the driver (offline feature
+        verification, Sentinel); recording is best-effort.
+    -->
+    <reference id="llmUsageMetrics" interface="org.opennms.alec.engine.api.llm.LlmUsageMetrics"
+               availability="optional"/>
+
     <service interface="org.opennms.alec.engine.api.EngineFactory" ranking="15">
         <bean class="org.opennms.alec.engine.llm.LlmEngineFactory">
             <argument ref="keyValueStore"/>
             <argument ref="llmEngineObjectMapper"/>
+            <argument ref="llmUsageMetrics"/>
         </bean>
     </service>
 

--- a/engine/llm/src/test/java/org/opennms/alec/engine/llm/LlmClusterEngineTest.java
+++ b/engine/llm/src/test/java/org/opennms/alec/engine/llm/LlmClusterEngineTest.java
@@ -479,4 +479,38 @@ public class LlmClusterEngineTest {
                 + "\"choices\":[{\"message\":{\"tool_calls\":[{\"function\":{\"name\":\"group_alarms\","
                 + "\"arguments\":\"" + args + "\"}}]}}]}";
     }
+
+    // --- ALEC-308: token usage gauges ---
+
+    @Test
+    public void recordUsageFeedsTheTokenUsageGauges() throws Exception {
+        org.opennms.alec.engine.api.llm.DefaultLlmUsageMetrics gauges =
+                new org.opennms.alec.engine.api.llm.DefaultLlmUsageMetrics();
+        LlmClusterEngine metered = new LlmClusterEngine(new MetricRegistry(), kvStore, om, null, gauges);
+        String resp = "{\"usage\":{\"prompt_tokens\":1000,\"completion_tokens\":50,"
+                + "\"prompt_tokens_details\":{\"cached_tokens\":200}}}";
+        metered.recordUsage(resp, MODEL, 1_700_000_000_000L);
+        assertThat(gauges.getTotalTokens(), equalTo(1050L));
+        assertThat(gauges.getTokens(org.opennms.alec.engine.api.llm.LlmUsageMetrics.Consumer.CLUSTERING), equalTo(1050L));
+        assertThat(gauges.getTokens(org.opennms.alec.engine.api.llm.LlmUsageMetrics.Consumer.RCA), equalTo(0L));
+    }
+
+    @Test
+    public void aThrowingMetricsSinkDoesNotBreakUsageRecording() throws Exception {
+        org.opennms.alec.engine.api.llm.LlmUsageMetrics broken = new org.opennms.alec.engine.api.llm.LlmUsageMetrics() {
+            @Override
+            public void recordRound(Consumer consumer, org.opennms.alec.engine.api.llm.TokenUsage usage) {
+                throw new IllegalStateException("driver bundle is down");
+            }
+
+            @Override
+            public void recordCall(Consumer consumer, boolean success) {
+                throw new IllegalStateException("driver bundle is down");
+            }
+        };
+        LlmClusterEngine metered = new LlmClusterEngine(new MetricRegistry(), kvStore, om, null, broken);
+        metered.recordUsage("{\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":1}}", MODEL, 1L);
+        assertThat("the usage row was still written", kvStore.enumerateContext(LlmClusterEngine.USAGE_CONTEXT).size(),
+                equalTo(1));
+    }
 }

--- a/features/llm-suggestions/pom.xml
+++ b/features/llm-suggestions/pom.xml
@@ -43,6 +43,10 @@
             <artifactId>api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.opennms.alec.engine</groupId>
+            <artifactId>org.opennms.alec.engine.api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.okhttp</artifactId>
         </dependency>

--- a/features/llm-suggestions/src/main/java/org/opennms/alec/llm/LlmSuggestionServiceImpl.java
+++ b/features/llm-suggestions/src/main/java/org/opennms/alec/llm/LlmSuggestionServiceImpl.java
@@ -43,6 +43,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.opennms.alec.datasource.api.Alarm;
 import org.opennms.alec.datasource.api.Situation;
+import org.opennms.alec.engine.api.llm.LlmUsageMetrics;
+import org.opennms.alec.engine.api.llm.TokenUsage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -155,13 +157,22 @@ public class LlmSuggestionServiceImpl implements LlmSuggestionService {
     private final ExecutorService executor;
     private final Semaphore inFlight;
     private final boolean ownsExecutor;
+    // ALEC-308: token-usage gauges (JMX). Null, or a blueprint proxy that may
+    // throw while the driver bundle is down — recording is best-effort.
+    private final LlmUsageMetrics usageMetrics;
 
     public LlmSuggestionServiceImpl() {
+        this((LlmUsageMetrics) null);
+    }
+
+    /** Blueprint constructor. */
+    public LlmSuggestionServiceImpl(LlmUsageMetrics usageMetrics) {
         this(buildDefaultHttpClient(),
                 new ObjectMapper(),
                 buildDefaultExecutor(),
                 DEFAULT_MAX_CONCURRENT,
-                true);
+                true,
+                usageMetrics);
     }
 
     // Visible for testing.
@@ -170,11 +181,37 @@ public class LlmSuggestionServiceImpl implements LlmSuggestionService {
                              ExecutorService executor,
                              int maxConcurrent,
                              boolean ownsExecutor) {
+        this(httpClient, objectMapper, executor, maxConcurrent, ownsExecutor, null);
+    }
+
+    // Visible for testing.
+    LlmSuggestionServiceImpl(OkHttpClient httpClient,
+                             ObjectMapper objectMapper,
+                             ExecutorService executor,
+                             int maxConcurrent,
+                             boolean ownsExecutor,
+                             LlmUsageMetrics usageMetrics) {
         this.httpClient = httpClient;
         this.objectMapper = objectMapper;
         this.executor = executor;
         this.inFlight = new Semaphore(maxConcurrent);
         this.ownsExecutor = ownsExecutor;
+        this.usageMetrics = usageMetrics;
+    }
+
+    private void recordMetrics(LlmUsageMetrics.Consumer consumer, Suggestions.TokenUsage usage, boolean success) {
+        if (usageMetrics == null) {
+            return;
+        }
+        try {
+            if (usage != null) {
+                usageMetrics.recordRound(consumer, new TokenUsage(usage.getInputTokens(), usage.getOutputTokens(),
+                        usage.getCacheReadInputTokens(), usage.getCacheCreationInputTokens()));
+            }
+            usageMetrics.recordCall(consumer, success);
+        } catch (RuntimeException e) {
+            LOG.debug("LLM usage metrics unavailable: {}", e.getMessage());
+        }
     }
 
     @Override
@@ -257,6 +294,7 @@ public class LlmSuggestionServiceImpl implements LlmSuggestionService {
             ResponseBody respBody = response.body();
             String text = respBody == null ? "" : respBody.string();
             if (!response.isSuccessful()) {
+                recordMetrics(LlmUsageMetrics.Consumer.VALIDATION, null, false);
                 return ValidationResult.fail("HTTP " + response.code() + " from provider: "
                         + providerError(text, objectMapper));
             }
@@ -264,8 +302,11 @@ public class LlmSuggestionServiceImpl implements LlmSuggestionService {
             JsonNode root = objectMapper.readTree(text);
             JsonNode err = root.get("error");
             if (err != null && !err.isNull()) {
+                recordMetrics(LlmUsageMetrics.Consumer.VALIDATION, null, false);
                 return ValidationResult.fail("Provider error: " + providerError(text, objectMapper));
             }
+            // The probe is billed like any other call; count it under its own consumer.
+            recordMetrics(LlmUsageMetrics.Consumer.VALIDATION, readUsage(root), responseHasReportToolCall(root));
             // The probe forces a tool call. If the response carries none, the
             // model is unusable for ALEC — but there are two distinct reasons,
             // and they need different fixes:
@@ -400,14 +441,26 @@ public class LlmSuggestionServiceImpl implements LlmSuggestionService {
             ResponseBody respBody = response.body();
             String text = respBody == null ? "" : respBody.string();
             if (!response.isSuccessful()) {
+                recordMetrics(LlmUsageMetrics.Consumer.RCA, null, false);
                 // providerError never reflects the raw body — the failure reason
                 // is persisted and displayed in the UI.
                 throw new LlmApiException(
                         "LLM API returned HTTP " + response.code() + ": "
                                 + providerError(text, objectMapper));
             }
-            return parseResponse(text, objectMapper);
+            Suggestions suggestions;
+            try {
+                suggestions = parseResponse(text, objectMapper);
+            } catch (LlmApiException | IOException e) {
+                // A 200 the provider billed but that carried no usable answer
+                // (error envelope, no tool call): still a call, and still spent.
+                recordMetrics(LlmUsageMetrics.Consumer.RCA, safeUsage(text), false);
+                throw e;
+            }
+            recordMetrics(LlmUsageMetrics.Consumer.RCA, suggestions.getUsage(), true);
+            return suggestions;
         } catch (IOException e) {
+            recordMetrics(LlmUsageMetrics.Consumer.RCA, null, false);
             throw new LlmApiException("Network error calling LLM", e);
         }
     }
@@ -599,6 +652,15 @@ public class LlmSuggestionServiceImpl implements LlmSuggestionService {
         List<String> rootCauses = readStringArray(input, "rootCauses");
         List<String> resolutions = readStringArray(input, "resolutions");
         return new Suggestions(rootCauses, resolutions, readUsage(root));
+    }
+
+    /** The usage block of a response that failed to parse as an answer, if the JSON is readable at all. */
+    private Suggestions.TokenUsage safeUsage(String text) {
+        try {
+            return readUsage(objectMapper.readTree(text));
+        } catch (IOException | RuntimeException e) {
+            return null;
+        }
     }
 
     private static Suggestions.TokenUsage readUsage(JsonNode root) {

--- a/features/llm-suggestions/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/llm-suggestions/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -9,6 +9,10 @@
 
     <bean id="llmObjectMapper" class="com.fasterxml.jackson.databind.ObjectMapper"/>
 
+    <!-- ALEC-308: LLM token usage gauges, published by the driver bundle (best-effort). -->
+    <reference id="llmUsageMetrics" interface="org.opennms.alec.engine.api.llm.LlmUsageMetrics"
+               availability="optional"/>
+
     <!--
         LlmSuggestionService — calls a configured OpenAI-compatible chat
         endpoint (OpenRouter by default) to produce up to 3 probable root
@@ -16,7 +20,9 @@
     -->
     <bean id="llmSuggestionService"
           class="org.opennms.alec.llm.LlmSuggestionServiceImpl"
-          destroy-method="shutdown"/>
+          destroy-method="shutdown">
+        <argument ref="llmUsageMetrics"/>
+    </bean>
 
     <service ref="llmSuggestionService"
              interface="org.opennms.alec.llm.LlmSuggestionService"/>

--- a/features/llm-suggestions/src/test/java/org/opennms/alec/llm/LlmSuggestionServiceImplTest.java
+++ b/features/llm-suggestions/src/test/java/org/opennms/alec/llm/LlmSuggestionServiceImplTest.java
@@ -516,4 +516,57 @@ public class LlmSuggestionServiceImplTest {
         assertNotNull(s);
         return s;
     }
+
+    // --- ALEC-308: token usage gauges ---
+
+    private static okhttp3.OkHttpClient scripted(java.util.Deque<String> bodies, java.util.Deque<Integer> codes) {
+        return new okhttp3.OkHttpClient.Builder().addInterceptor(chain -> new okhttp3.Response.Builder()
+                .request(chain.request()).protocol(okhttp3.Protocol.HTTP_1_1)
+                .code(codes.isEmpty() ? 200 : codes.pop()).message("OK")
+                .body(okhttp3.ResponseBody.create(okhttp3.MediaType.parse("application/json"), bodies.pop()))
+                .build()).build();
+    }
+
+    @Test
+    public void successfulAnalysisRecordsTokensAndACallUnderRca() throws Exception {
+        org.opennms.alec.engine.api.llm.DefaultLlmUsageMetrics gauges =
+                new org.opennms.alec.engine.api.llm.DefaultLlmUsageMetrics();
+        java.util.Deque<String> bodies = new java.util.ArrayDeque<>();
+        bodies.push("{\"choices\":[{\"message\":{\"tool_calls\":[{\"function\":{\"name\":\"report_suggestions\","
+                + "\"arguments\":\"{\\\"rootCauses\\\":[\\\"a\\\"],\\\"resolutions\\\":[]}\"}}]}}],"
+                + "\"usage\":{\"prompt_tokens\":300,\"completion_tokens\":20,\"prompt_tokens_details\":{\"cached_tokens\":100}}}");
+        LlmSuggestionServiceImpl svc = new LlmSuggestionServiceImpl(scripted(bodies, new java.util.ArrayDeque<>()), om,
+                java.util.concurrent.Executors.newSingleThreadExecutor(), 1, true, gauges);
+        try {
+            Suggestions s = svc.requestSuggestions(stubSituation(), "sk-x", BASE_URL, MODEL, PROMPT).get();
+            assertThat(s.getRootCauses().size(), equalTo(1));
+            assertThat(gauges.getTotalTokens(), equalTo(320L));
+            assertThat(gauges.getTokens(org.opennms.alec.engine.api.llm.LlmUsageMetrics.Consumer.RCA), equalTo(320L));
+            assertThat(gauges.getCalls(), equalTo(1L));
+            assertThat(gauges.getFailedCalls(), equalTo(0L));
+        } finally {
+            svc.shutdown();
+        }
+    }
+
+    @Test
+    public void failedAnalysisStillCountsTheCallAndAnyBilledTokens() throws Exception {
+        org.opennms.alec.engine.api.llm.DefaultLlmUsageMetrics gauges =
+                new org.opennms.alec.engine.api.llm.DefaultLlmUsageMetrics();
+        java.util.Deque<String> bodies = new java.util.ArrayDeque<>();
+        // A 200 with no tool call but a usage block: billed, unusable.
+        bodies.push("{\"choices\":[{\"message\":{\"content\":\"hi\"},\"finish_reason\":\"stop\"}],"
+                + "\"usage\":{\"prompt_tokens\":40,\"completion_tokens\":2}}");
+        LlmSuggestionServiceImpl svc = new LlmSuggestionServiceImpl(scripted(bodies, new java.util.ArrayDeque<>()), om,
+                java.util.concurrent.Executors.newSingleThreadExecutor(), 1, true, gauges);
+        try {
+            Throwable cause = futureCause(svc.requestSuggestions(stubSituation(), "sk-x", BASE_URL, MODEL, PROMPT));
+            assertThat(cause instanceof LlmApiException, is(true));
+            assertThat(gauges.getCalls(), equalTo(1L));
+            assertThat(gauges.getFailedCalls(), equalTo(1L));
+            assertThat(gauges.getTotalTokens(), equalTo(42L));
+        } finally {
+            svc.shutdown();
+        }
+    }
 }

--- a/karaf-features/src/main/resources/features.xml
+++ b/karaf-features/src/main/resources/features.xml
@@ -80,6 +80,7 @@
     <feature name="alec-features-llm-suggestions"
              description="ALEC :: Features :: LLM Suggestions" version="${project.version}">
         <feature version="${project.version}">alec-datasource-api</feature>
+        <feature version="${project.version}">alec-engine-api</feature>
         <feature version="${opennms.api.version}" dependency="true">opennms-integration-api</feature>
         <bundle dependency="true">mvn:javax.ws.rs/javax.ws.rs-api/${jaxrs.version}</bundle>
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okio/${okio.bundle.version}</bundle>


### PR DESCRIPTION
Jira: https://opennms.atlassian.net/browse/ALEC-308

First slice of ALEC-308, split out of #176: LLM token usage as ALEC metrics that OpenNMS charts on the node's Resource Graphs.

- Every LLM call — root cause analysis, LLM clustering, the configuration-page probes — records its token usage and outcome into a metric set of gauges: total, the four billing buckets, per consumer, calls and failures, and one- and five-minute token rates.
- The driver folds any `MetricSet` OSGi service into its JMX-reported registry, so the gauges appear in the `Driver.<engine>` domain that OpenNMS's stock JMX collection already collects as "ALEC Graph Stats"; no OpenNMS configuration change.
- The sink interface and default implementation live in `engine/api`, reachable from both the engine and the suggestions bundle; the driver owns the bean and publishes it.
- References are optional and recording is best-effort, so the bundles still resolve without the driver and the Karaf feature verification stays green.
- Counters reset on bundle restart; the KV usage store remains the durable per-call history behind the settings page and the token budgets.
- Reference docs gain a "Usage metrics on the Resource Graphs" section with the gauge table.